### PR TITLE
fix: Read options when includeUi is false too

### DIFF
--- a/src/ImageEditor.vue
+++ b/src/ImageEditor.vue
@@ -28,9 +28,9 @@ export default {
     }
   },
   mounted() {
-    let options = editorDefaultOptions;
+    let {options} = this;
     if (this.includeUi) {
-      options = Object.assign(includeUIOptions, this.options);
+      options = Object.assign(includeUIOptions, options);
     }
     this.editorInstance = new ImageEditor(this.$refs.tuiImageEditor, options);
     this.addEventListener();


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [X] It's submitted to right branch according to our branching model
- [X] It's right issue type on title
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [X] It does not introduce a breaking change or has description for the breaking change

### Description

When the `includeUi` prop is set to false, `ImageEditor` ignores any other options passed to it and always uses `editorDefaultOptions` instead. A workaround is to set `includeUi = true` and set `options = { includeUI: null, ...otheroptions }` but I suppose this is not the intended behavior.

This PR fixes this and `editorDefaultOptions` is used by default if no options are passed to the component.

This library is great by the way, thank you for working on this.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
